### PR TITLE
support for 128 UUID

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -170,7 +170,7 @@ int main(int n, char* v[])
 #ifdef XECHO_BLENO
         IServer* BS =  ctx->new_server(&procedure, dev, "echo", srdel, true);
 #else
-        IServer* BS =  ctx->new_server(&procedure, dev, "bunget", srdel, true);
+        IServer* BS =  ctx->new_server(&procedure, dev, "bunget", srdel, true, true);
 #endif
 #if 0   // not tested !!!
         //BS->set_name("advname"); // this is the bt name.

--- a/lib/bu_gatt.cpp
+++ b/lib/bu_gatt.cpp
@@ -268,7 +268,15 @@ int bu_gatt::_group_q(const sdata& data, bybuff& ret)
             ret << uint16_t(ps->_lasthndl);
 
             TRACE(" adding service " << std::hex << int(ps->_hndl) << std::dec<<"\n");
-            ret << ps->_cuid;
+
+            // can not mix up 128 bit uuids with 16 bit
+            assert((lengthPerService == 20 && !ps->_cuid.is_16()) || (lengthPerService == 6 && ps->_cuid.is_16()));
+            if(ps->_cuid.is_16()){
+                ret << ps->_cuid.as16();
+            } else {
+                ret << ps->_cuid.as128();
+            }
+
 
             if(--elems==0)
                 break;

--- a/lib/include/libbunget.h
+++ b/lib/include/libbunget.h
@@ -240,7 +240,7 @@ public:
     virtual ~BtCtx();
 
     static BtCtx* instance();
-    virtual IServer* new_server(ISrvProc* proc, int hcidev, const char* name, int tweak_delay=0, bool advall=0)=0;
+    virtual IServer* new_server(ISrvProc* proc, int hcidev, const char* name, int tweak_delay=0, bool advall=0, bool defaults = true)=0;
 };
 
 /**

--- a/lib/libbungetpriv.cpp
+++ b/lib/libbungetpriv.cpp
@@ -44,7 +44,7 @@ inline size_t tick_count()
 
 /****************************************************************************************
 */
-SrvDevice::SrvDevice(ISrvProc* proc, int& hcid, const char* name, int delay, bool advall):_cb_proc(proc),
+SrvDevice::SrvDevice(ISrvProc* proc, int& hcid, const char* name, int delay, bool advall, bool defaults):_cb_proc(proc),
                     _def(false),_hcidev(hcid),_advinterval(MIN_ADV_INTERVAL),_advall(advall),_notyinterval(MIN_NOTY_INTERVAL)
 {
     _gapp = 0;
@@ -57,7 +57,7 @@ SrvDevice::SrvDevice(ISrvProc* proc, int& hcid, const char* name, int delay, boo
     _advstatus = 0;
     _scanrespdatastatus = 0;
     _advstatus = 0;
-    _defaults = false;
+    _defaults = !defaults;
     _status = eOFFLINE;
     _maxMtu = 23;
     _pcrypt = _cb_proc->get_crypto();
@@ -663,11 +663,12 @@ IServer* ContextImpl::new_server(ISrvProc* proc,
                                 int hcidev, 
                                 const char* name, 
                                 int tweak_delay,
-                                bool advall)
+                                bool advall,
+                                bool defaults)
 {
     if(_adapters.find(hcidev) == _adapters.end())
     {
-        SrvDevice* p = new SrvDevice(proc, hcidev, name, tweak_delay, advall);
+        SrvDevice* p = new SrvDevice(proc, hcidev, name, tweak_delay, advall, defaults);
         if(hcidev<0){
             delete p;
             return 0;

--- a/lib/libbungetpriv.h
+++ b/lib/libbungetpriv.h
@@ -45,7 +45,8 @@ enum {
 class SrvDevice : public IServer, public hci_event
 {
 public:
-    SrvDevice(ISrvProc* proc, int& hcid, const char* name, int delay=0, bool advall=false);
+    // defaults enables the default services 1800 and 1801. This just works with 16 bit UUID services
+    SrvDevice(ISrvProc* proc, int& hcid, const char* name, int delay=0, bool advall=false, bool defaults = true);
     ~SrvDevice();
     void   power_switch(bool on);
     int    advertise(int millis);
@@ -196,7 +197,7 @@ public:
             delete a.second;
 
     }
-    virtual IServer* new_server(ISrvProc* proc, int hcidev, const char* name, int tweak_delay=0, bool advall=false);
+    virtual IServer* new_server(ISrvProc* proc, int hcidev, const char* name, int tweak_delay=0, bool advall=false, bool defaults = true);
  private:
     std::map<int,IServer*> _adapters;
 };


### PR DESCRIPTION
it is possible to use 128bit UUIDs in services like ("cd54b00b-880b-425b-1234-12346a15e913") and the generic ids 0x1800 0x1801 can be disabled.

pay attention: its not possible to mix 128 and 16 bit.

[issue with this topic](https://github.com/comarius/bunget/issues/7)

this patch allows code like

```
  +        bt_uuid_t uuid;
  +        memset(&uuid, 0, sizeof(bt_uuid_t));
  +        bt_string_to_uuid(&uuid, "00001815-0000-1000-8000-00805f9b34fb");
  +
  +        IService*   ps = BS->add_service(uuid,"bunget");
```